### PR TITLE
#9 `uniqueForm` na formuláři s nataveným atibutem `target`

### DIFF
--- a/extensions/uniqueForm.ajax.js
+++ b/extensions/uniqueForm.ajax.js
@@ -12,6 +12,10 @@
 		init: function () {
 			var uniqueForm = this;
 			$(document).on('submit', 'form', function () {
+				if (this.target === '_blank' || (this.target === '_parent' && window.parent !== window)) {
+					return true;
+				}
+
 				uniqueForm.formSubmitBeforeHandler.call(uniqueForm, this);
 				$(this).data('uniqueFormTimeout', setTimeout(uniqueForm.formSubmitAfterHandler.bind(uniqueForm, this), uniqueForm.timeout));
 			});


### PR DESCRIPTION
PR k úkolu #9. V případě, že má formulář nastavený `target` tak, že se bude odesílat do nového okna, nebude se extension na tomto formuláři používat.