### PR TITLE
#13 Historie a pdbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ Vlastní extensions pro nette.ajax
 
 ## Changelog
 
+### 1.4.0 draft
+- U pdboxu je možné nastavit způsob fungování historie po zavření. Výchozí je, že po zavření přejde prohlížeč zpět do stavu před otevřením a v historii prohlížeče je pdbox možno otevřít tlačítkem vpřed. Pomocí `data-pdbox-history="forwards"` je možné nastavit, že při zavření se vytvoří nový stav do historie, tj. tlačítko zpět v prohlížeči otevře znovu tento pdbox.
+  
+  :warning: **BC break:** původní výchozí chování bylo to, které je nyní volitelné.
+
 ### 1.3.1
 - Extension `uniqueForm` nechává tlačítka disabled, pokud v odpovědi přišel `forceRedirect`. V takovém případě není žádoucí odebrat `disabled`, nicméně běží dál 60s limit.
 
@@ -30,7 +35,7 @@ Vlastní extensions pro nette.ajax
 ### 1.2.0
 - extension `pdbox` upraveno pro kompatibilitu s `jquery.pdbox` verze `~1.2.0` - tato verze je nyní vyžadována
 - oprava JS chyby v extension `pdbox` v případě, kdy byl nějaký AJAXový požadavek vyslán dříve, než byl předán parametr `box`   
-- extension `btnSpinner` je možno vypnout i ne ne-AJAXových formulářích pomocí data atributu `data-no-spinner` nebo `data-no-btn-spinner`
+- extension `btnSpinner` je možno vypnout i na ne-AJAXových formulářích pomocí data atributu `data-no-spinner` nebo `data-no-btn-spinner`
 
 ### 1.1.5
 - oprava [#12](https://github.com/peckadesign/pd.ajax/issues/12)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,14 @@ Vlastní extensions pro nette.ajax
 
 ### 1.4.0 draft
 - U pdboxu je možné nastavit způsob fungování historie po zavření. Výchozí je, že po zavření přejde prohlížeč zpět do stavu před otevřením a v historii prohlížeče je pdbox možno otevřít tlačítkem vpřed. Pomocí `data-pdbox-history="forwards"` je možné nastavit, že při zavření se vytvoří nový stav do historie, tj. tlačítko zpět v prohlížeči otevře znovu tento pdbox.
-  
-  :warning: **BC break:** původní výchozí chování bylo to, které je nyní volitelné.
+- V jednotlivých extension je v `settings.pd` dostupné pole pro request zapnutých pd extension. 
+- Do extension se neukládá každý `xhr`, ale pouze ty, které opravdu souvisí s `pdboxem`. Stejně tak k rušení dojde pouze v případě, že oba requesty (probíhající i nový) souvisí s `pdboxem`. Opravuje #7.
+- Přesunutí automatického přidávání class `js-pdbox` (obecně dle nastavení `autoclass` u extension) tak, aby i při `popstate` došlo k nastavení class uvnitř pdboxu, opravuje #15.
+
+
+- **Nové extension:** Přidáno extension `replaceState` pro zachování změny url bez vytváření nových stavů. Toto extension je možné použít obecně vždy, když chceme mít aktuální url, ale v historii nechceme vytvářet nový stav. Například přepínání barev produktů nebo formuláře v pdboxu.
+
+:warning: **BC break:** původní výchozí chování historie pdboxu bylo to, které je nyní volitelné, tj. vytváření nového stavu po zavření. Pro zachování tohoto chování je potřeba doplnit zmíněný data atribut `data-pdbox-history="forwards"`.
 
 ### 1.3.1
 - Extension `uniqueForm` nechává tlačítka disabled, pokud v odpovědi přišel `forceRedirect`. V takovém případě není žádoucí odebrat `disabled`, nicméně běží dál 60s limit.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Vlastní extensions pro nette.ajax
 
 ## Changelog
 
-### 1.4.0 draft
+### 1.4.0
 - U pdboxu je možné nastavit způsob fungování historie po zavření. Výchozí je, že po zavření přejde prohlížeč zpět do stavu před otevřením a v historii prohlížeče je pdbox možno otevřít tlačítkem vpřed. Pomocí `data-pdbox-history="forwards"` je možné nastavit, že při zavření se vytvoří nový stav do historie, tj. tlačítko zpět v prohlížeči otevře znovu tento pdbox.
 - V jednotlivých extension je v `settings.pd` dostupné pole pro request zapnutých pd extension. 
 - Do extension se neukládá každý `xhr`, ale pouze ty, které opravdu souvisí s `pdboxem`. Stejně tak k rušení dojde pouze v případě, že oba requesty (probíhající i nový) souvisí s `pdboxem`. Opravuje #7.
@@ -11,6 +11,9 @@ Vlastní extensions pro nette.ajax
 
 
 - **Nové extension:** Přidáno extension `replaceState` pro zachování změny url bez vytváření nových stavů. Toto extension je možné použít obecně vždy, když chceme mít aktuální url, ale v historii nechceme vytvářet nový stav. Například přepínání barev produktů nebo formuláře v pdboxu.
+- **Nové extension:** Přidáno extension `suggest` pro obsluhu našeptávače. Pro funkční použití je potřeba na formulář přidat class `js-suggest`, dále je nutné označit input (`js-suggest__input`), našeptávací tlačítko (`js-suggest__btn`) a snippet s výsledky našeptávání (`js-suggest__suggest`).
+- **Nové extension:** Přidáno extension `inpCombined` pro styl inputů s labelem uvnitř.
+- **Nové extension:** Přidáno extension `inpNumber` pro inputy s tlačítky + a &minus;.
 
 :warning: **BC break:** původní výchozí chování historie pdboxu bylo to, které je nyní volitelné, tj. vytváření nového stavu po zavření. Pro zachování tohoto chování je potřeba doplnit zmíněný data atribut `data-pdbox-history="forwards"`.
 

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
 	"dependencies": {
 		"jquery": ">=1.12",
 		"nette-forms": "~2.2",
-		"nette.ajax.js": ">=2.0 <2.4",
+		"nette.ajax.js": "zipper/nette.ajax.js#~2.4.0",
 		"jquery.pdbox": "peckadesign/jquery.pdbox#^1.2.0"
 	}
 }

--- a/extensions/pd/inpCombined.ajax.js
+++ b/extensions/pd/inpCombined.ajax.js
@@ -1,0 +1,52 @@
+(function($, undefined) {
+
+	/**
+	 * @author Radek Šerý
+	 *
+	 * Inicializace .inp-combined elementů
+	 */
+	$.nette.ext('inpCombined', {
+		init: function() {
+			var snippetsExt = this.ext('snippets', true);
+			var ext = this;
+
+
+			snippetsExt.after(function($el) {
+				$el.find(ext.selector + '__input')
+					.trigger('focusout')
+					.hide().show();
+			});
+
+
+			var className = ext.selector.substring(1);
+
+			$(document)
+				.on('focusin', this.selector + '__input', function(e) {
+					$(this).closest(ext.selector).addClass(className + '--focus');
+				})
+				.on('focusout change', ext.selector + '__input', function(e) {
+					var $inpCombined = $(this).closest(ext.selector);
+
+					if ($inpCombined.hasClass(className + '--static')) {
+						return;
+					}
+
+					if ($(this).val().length) {
+						$inpCombined.addClass(className + '--filled');
+					} else {
+						$inpCombined.removeClass(className + '--filled');
+					}
+
+					if (e.type === 'focusout') {
+						$inpCombined.removeClass(className + '--focus');
+					}
+				})
+				.find(ext.selector + '__input')
+					.trigger('focusout')
+					.hide().show();
+		}
+	}, {
+		selector: '.inp-combined'
+	});
+
+})(jQuery);

--- a/extensions/pd/inpNumber.ajax.js
+++ b/extensions/pd/inpNumber.ajax.js
@@ -1,0 +1,205 @@
+(function($, undefined) {
+
+	var InpNumber = function(el) {
+		var $el = $(el);
+		var _this = this;
+
+		this.$input = $el.find('.inp-number__input');
+
+		this.$inc = $('<a href="#" class="inp-number__btn inp-number__btn--inc"><span>+</span></a>');
+		this.$dec = $('<a href="#" class="inp-number__btn inp-number__btn--dec"><span>&minus;</span></a>');
+		this.$btns = this.$inc.add(this.$dec);
+
+		this.min = parseInt(this.$input.attr('min') || 0);
+		this.max = parseInt(this.$input.attr('max') || Number.MAX_SAFE_INTEGER);
+
+		this.timer = null;
+
+		$el.find('.inp-number__btn').remove();
+		$el
+			.data('initialized', true)
+			.prepend(this.$dec)
+			.append(this.$inc);
+
+		// inicializace, upravení hodnoty do intervalu <min;max>, vypnutí tlačítek
+		this.adjustValue();
+		this.setDisabledBtns();
+
+		// bind handlers
+		this.$btns
+			.on('click', $.proxy(this.handleClick, this))
+			.on('contextmenu', function(e) { e.preventDefault(); }) // longtap na Android zařízeních otevírá menu; pro iOS je nutné uvést v css -webkit-touch-callout: none;
+			.on('mousedown longtap', $.proxy(this.startRapidChange, this))
+			.on('mouseup mouseleave touchend touchcancel', $.proxy(this.stopRapidChange, this));
+
+		this.$input
+			.on('change', $.proxy(this.handleChange, this)) // mouseup není vyvoláno, pokud z tlačítka sjedeme, proto mouseleave
+			.on('focus', $.proxy(this.handleFocus, this));
+	};
+
+	InpNumber.prototype = {
+		getValue: function() {
+			return parseInt(this.$input.val()) || 0;
+		},
+		setValue: function(value) {
+			this.$input.val(value);
+		},
+		getOp: function(e) {
+			return e.currentTarget === this.$dec[0] ? 'getDecrement' : 'getIncrement';
+		},
+		isClickedBtnDisabled: function(e) {
+			return $(e.currentTarget).data('disabled');
+		},
+
+		getIncrement: function(value) {
+			value++;
+
+			return value > this.max ? this.max : value;
+		},
+		getDecrement: function(value) {
+			value--;
+
+			return value < this.min ? this.min : value;
+		},
+
+		valueChanged: function() {
+			this.$input.trigger('change');
+		},
+		adjustValue: function() {
+			var value = this.getValue();
+			value = value < this.min ? this.min : (value > this.max ? this.max : value);
+
+			this.setValue(value);
+		},
+		setDisabledBtns: function() {
+			var value = this.getValue();
+
+			this.$btns
+				.data('disabled', false)
+				.removeClass('inp-number__btn--disabled');
+
+			if (value === this.min) {
+				this.$dec
+					.data('disabled', true)
+					.addClass('inp-number__btn--disabled');
+			}
+			if (value === this.max) {
+				this.$inc
+					.data('disabled', true)
+					.addClass('inp-number__btn--disabled');
+			}
+		},
+
+		handleClick: function(e) {
+			e.preventDefault();
+
+			// rapidChangeFlag flag je nastavován v případě mousedown, tj. pokud měníme hodnotu vícenásobně
+			if (! this.rapidChangeFlag && ! this.isClickedBtnDisabled(e)) {
+				var value = this.getValue();
+				var op = this.getOp(e);
+
+				value = this[op](value);
+				this.setValue(value);
+
+				this.valueChanged();
+			}
+
+			// musíme nastavit zde, protože click je vyvolán až po mouseup události
+			this.rapidChangeFlag = false;
+		},
+		handleChange: function() {
+			this.adjustValue();
+			this.setDisabledBtns();
+		},
+		handleFocus: function() {
+			this.$input[0].select();
+		},
+
+		startRapidChange: function(e) {
+			e.preventDefault();
+
+			// už zpracováváme z click event -> desktop, takže longtap ignorujeme
+			if (e.type === 'longtap' && this.rapidChangeFlag) {
+				return;
+			}
+
+			var _this = this;
+			var value = this.getValue();
+			var op = this.getOp(e);
+			var counter = 0;
+
+			var rapidChange = function() {
+				counter++;
+				newValue = _this[op](value);
+
+				_this.rapidChangeFlag = true;
+
+				if (value !== newValue) {
+					value = newValue;
+
+					_this.valueChangedFlag = true;
+					_this.setValue(value);
+
+					if (counter === 1) {
+						_this.setDisabledBtns();
+					}
+				}
+				// hodnota se v této iteraci nezměnila -> narazili jsme na min/max hodnotu, urychlíme vyvolání change eventy
+				else {
+					if (_this.valueChangedFlag) {
+						_this.stopRapidChange();
+					}
+					return;
+				}
+
+				var delay = 150;
+				if (counter > 10) {
+					delay = Math.max(10, delay - 5 * counter);
+				}
+				_this.timer = setTimeout(rapidChange, delay);
+			};
+
+			this.timer = setTimeout(rapidChange, 300);
+		},
+		stopRapidChange: function(e) {
+			clearTimeout(this.timer);
+
+			if (this.valueChangedFlag) {
+				this.valueChanged();
+				this.valueChangedFlag = false;
+			}
+		}
+	};
+
+
+	/**
+	 * @author Radek Šerý
+	 *
+	 * Inicializace .inp-number elementů, dynamicky vytvoří tlačítka a naváže eventy
+	 */
+	$.nette.ext('inpNumber', {
+		init: function() {
+			var snippetsExt = this.ext('snippets', true);
+			var ext = this;
+
+			snippetsExt.after(function($el) {
+				ext.init.call(ext, $el);
+			});
+
+			this.init($(document));
+		}
+	}, {
+		selector: '.inp-number',
+
+		init: function($el) {
+			var ext = this;
+
+			$el
+				.find(this.selector)
+				.each(function() {
+					var inpNumber = new InpNumber(this);
+				});
+		}
+	});
+
+})(jQuery);

--- a/extensions/pd/replaceState.ajax.js
+++ b/extensions/pd/replaceState.ajax.js
@@ -1,0 +1,55 @@
+(function($, undefined) {
+
+	// Is History API reliably supported? (based on Modernizr & PJAX)
+	if (!(window.history && history.pushState && window.history.replaceState)) {
+		return;
+	}
+
+	/**
+	 * @author Radek Šerý
+	 *
+	 * Extension pro AJAXové odkazy, které mění url, ale v historii nahrazují stávající state, tj. v historii se projeví
+	 * pouze poslední request. Použito např. pro odkazy na varianty produktu - lze sdílet vždy aktuální variantu, ale
+	 * klik na zpět vrací na výpis a ne na všechny proklikané varianty.
+	 */
+	$.nette.pd.ext('replaceState', {
+		init: function() {
+			this.historyExt = $.nette.ext('history');
+			this.snippetsExt = $.nette.ext('snippets');
+		},
+		before: function (xhr, settings) {
+			if (! settings.nette) {
+				this.href = null;
+			} else if (! settings.nette.form) {
+				this.href = settings.nette.ui.href;
+			} else if (settings.nette.form.get(0).method === 'get') {
+				this.href = settings.nette.form.get(0).action || window.location.href;
+			} else {
+				this.href = null;
+			}
+		},
+		success: function(payload) {
+			var redirect = payload.redirect || payload.url; // backwards compatibility for 'url'
+			if (redirect) {
+				var regexp = new RegExp('//' + window.location.host + '($|/)');
+				if ((redirect.substring(0,4) === 'http') ? regexp.test(redirect) : true) {
+					this.href = redirect;
+				} else {
+					window.location.href = redirect;
+				}
+			}
+
+			if (this.href && this.href !== window.location.href) {
+				history.replaceState({
+					nette: true,
+					href: this.href,
+					title: document.title,
+					ui: (this.historyExt && this.historyExt.cache && this.snippetsExt) ? this.snippetsExt.findSnippets() : null
+				}, document.title, this.href);
+			}
+
+			this.href = null;
+		}
+	});
+
+})(jQuery);

--- a/extensions/pd/suggest.ajax.js
+++ b/extensions/pd/suggest.ajax.js
@@ -1,0 +1,198 @@
+(function($, undefined) {
+
+	/* Třída pro našeptávač jako takový */
+	var pdSuggest = function(form, options) {
+		var inputSelector   = '.js-suggest__input';
+		var btnSelector     = '.js-suggest__btn';
+		var suggestSelector = '.js-suggest__suggest';
+
+		var _this = this;
+		this.$form = $(form);
+
+		this.$input   = this.$form.find(inputSelector);
+		this.$btn     = this.$form.find(btnSelector);
+		this.$suggest = this.$form.find(suggestSelector);
+
+		this.timer = null;
+		this.hideSuggestTimer = null;
+		this.lastSearched = '';
+		this.minLength = options.minLength || 2;
+		this.timeout = options.timeout || 200;
+
+		this.$form
+			.on('keydown', inputSelector, $.proxy(this.handleInputKeydown, this))
+			.on('keyup', inputSelector, $.proxy(this.handleInputKeyup, this));
+
+		this.$input
+			.data('document-tap-blur', false)
+			.on('focus', $.proxy(this.showSuggest, this))
+			.on('blur', $.proxy(this.hideSuggest, this));
+
+		this.$suggest
+			.on('mousedown', $.proxy(this.handleSuggestMousedown, this));
+
+		this.$form.data('pdSuggest', this);
+	};
+	pdSuggest.prototype.hideSuggest = function() {
+		this.isOpen = false;
+		this.$suggest.removeClass('js-suggest__suggest--shown');
+	};
+	pdSuggest.prototype.showSuggest = function() {
+		this.isOpen = true;
+		this.$suggest.addClass('js-suggest__suggest--shown');
+	};
+	pdSuggest.prototype.emptySuggest = function() {
+		this.$suggest
+			.addClass('js-suggest__suggest--empty')
+			.empty();
+	};
+
+	pdSuggest.prototype.handleInputKeydown = function(e) {
+		// zavření na klávesu escape, posun šipkami v našeptávači, odeslání/zavření enterem
+		var $a;
+
+		switch (e.keyCode) {
+			case 27: // Escape
+				e.preventDefault();
+				this.$form.collapsable('collapseAll', e);
+				break;
+			case 40: // Down
+			case 38: // Up
+				e.preventDefault();
+
+				$a = this.$form.find('.js-suggest__link');
+				var $active = $a.filter('.js-suggest__link--active');
+				var i = $a.index($active);
+
+				$active.removeClass('js-suggest__link--active');
+				if (i === -1) { // není nic active, vybereme první/poslední
+					if (e.keyCode === 40)
+						$a.first().addClass('js-suggest__link--active');
+					else
+						$a.last().addClass('js-suggest__link--active');
+				}
+				else if (i === 0 && e.keyCode === 38) {} // NOP, aktivní je první + šipka nahoru => nic není aktivní
+				else {
+					if (e.keyCode === 40)
+						$a.eq(i+1).addClass('js-suggest__link--active');
+					else
+						$a.eq(i-1).addClass('js-suggest__link--active');
+				}
+
+				break;
+
+			case 13: // Enter
+				$a = this.$form.find('.js-suggest__link--active');
+				if ($a.length) {
+					location.href = $a.attr('href');
+
+					e.preventDefault();
+					e.stopPropagation();
+				}
+
+				break;
+
+			default:
+				break;
+		}
+	};
+	pdSuggest.prototype.handleInputKeyup = function(e) {
+		clearTimeout(this.timer);
+
+		var query = $(e.target).val();
+
+		if (query.length < this.minLength) {
+			this.hideSuggest();
+		}
+
+		if (query.length >= this.minLength) {
+			// pokud byl suggest zavřený, tak ho otevřeme
+			if (! this.isOpen) {
+				// ještě předtím ale vyprázdníme, pokud query neodpovídá poslednímu hledanému
+				if (query !== this.lastSearched) {
+					this.emptySuggest();
+				}
+
+				this.showSuggest();
+			}
+
+			if (query !== this.lastSearched) {
+				var _this = this;
+				this.timer = setTimeout(function() {
+					_this.lastSearched = query;
+
+					_this.$btn.click();
+				}, this.timeout);
+			}
+		}
+	};
+
+	pdSuggest.prototype.handleSuggestMousedown = function(e) {
+		e.preventDefault();
+	};
+
+
+	/**
+	 * @author Radek Šerý
+	 *
+	 * Našeptávač jako součást nette.ajax, obstarává spinner a odeslání requestu
+	 */
+	$.nette.pd.ext('suggest', {
+		init: function() {
+			this.attachHandlers();
+			this.attachExtension($(this.selector));
+		},
+		start: function(xhr, settings) {
+			if ('nette' in settings && settings.nette.form) {
+				var pdSuggest = settings.nette.form.data('pdSuggest');
+
+				if (pdSuggest) {
+					pdSuggest.$input.addClass('inp-text--loading');
+				}
+			}
+		},
+		complete: function(xhr, status, settings) {
+			if ('nette' in settings && settings.nette.form) {
+				var pdSuggest = settings.nette.form.data('pdSuggest');
+
+				if (pdSuggest) {
+					pdSuggest.$input.removeClass('inp-text--loading');
+
+					if (pdSuggest.$suggest[0].hasChildNodes()) {
+						pdSuggest.$suggest.removeClass('js-suggest__suggest--empty');
+					} else {
+						pdSuggest.$suggest.addClass('js-suggest__suggest--empty');
+					}
+				}
+			}
+		}
+	}, {
+		timeout: 200,
+		minLength: 2,
+		selector: '.js-suggest',
+		attachHandlers: function() {
+			var ext = this;
+
+			$(ext.selector).each(function() {
+				var suggest = new pdSuggest(this, ext.timeout, ext.minLength);
+			});
+		},
+		attachExtension: function ($el) {
+			var ext = this;
+
+			if ($el.closest(ext.selector).length === 0) {
+				return;
+			}
+
+			$el.find(ext.selector + '__btn').each(function () {
+				var pdExtensions = $(this).attr('data-ajax-pd') || '';
+				pdExtensions += (pdExtensions ? ' ' : '') + ext.name();
+
+				$(this)
+					.addClass('ajax')
+					.attr('data-ajax-pd', pdExtensions);
+			});
+		}
+	});
+
+})(jQuery);

--- a/extensions/pdbox.ajax.js
+++ b/extensions/pdbox.ajax.js
@@ -125,12 +125,22 @@
 			}
 		},
 		success: function (payload, status, xhr, settings) {
+			var $ajaxified = null;
+
 			this.popstate = false;
 			this.lastState = {
 				location: location.href,
 				state: history.state,
 				title: document.title
 			};
+
+
+			// navázání autoclass; při popstate není splněna podmínka isPdboxRequest, proto kontrolujeme pouze zda je pdbox otevřený (a není redirect)
+			if (! payload.redirect && this.box && this.box.isOpen) {
+				$ajaxified = this.box.window.content.find(this.ajaxified);
+				$ajaxified.addClass(this.pdboxAutoClass);
+			}
+
 
 			// pokud success nastal po kliknutí na elementu s class this.pdboxSelector, vyvoláme load událost, nastavíme vlastnosti pdbox a pokud je povolená historie, nahradíme stávající stav naším, kde přidáváme do state vlastnost pdbox
 			if (isPdboxRequest(this, settings)) {
@@ -146,11 +156,10 @@
 
 				var $opener = ('nette' in settings && 'el' in settings.nette && settings.nette.el) ? settings.nette.el : null;
 
-				var $ajaxified = this.box.window.content.find(this.ajaxified);
-				$ajaxified.addClass(this.pdboxAutoClass);
 
 				// Pokud není historie při otevírání, vypneme ji i pro automaticky zAJAXované odkazy a formuláře
 				if (! requestHistory) {
+					$ajaxified = $ajaxified || this.box.window.content.find(this.ajaxified);
 					$ajaxified.each(function() {
 						var off = $(this).attr('data-ajax-off') || '';
 

--- a/extensions/pdbox.ajax.js
+++ b/extensions/pdbox.ajax.js
@@ -11,48 +11,98 @@
 	 * @todo Nemělo by v lastState a original být též uloženo ui?
 	 */
 
-	// init a snippets jsou definovány v nette.ajax.js a history v history.nette.ajax.js, tj. vždy jsou v tuto chvíli dostupné (soubory musí být před pd.ajax soubory)
+
+	/**
+	 * Načtení vybraných extension, se kterými budeme pracovat. `init` a `snippets` jsou definovány v nette.ajax.js a
+	 * `history` v history.nette.ajax.js, tj. vždy jsou v tuto chvíli dostupné (soubory musí být před pd.ajax soubory).
+	 */
 	var snippetsExt = $.nette.ext('snippets');
 	var historyExt = $.nette.ext('history');
 	var initExt = $.nette.ext('init');
 
+
+	/**
+	 * Mód fungování historie (pokud je zapnutá) pdboxu
+	 * 0    při zavření se vrací v historii zpět do stavu před otevřením (výchozí)
+	 * 1    při zavření se vytváří nový stav
+	 */
+	var mode;
+	var PDBOX_HISTORY_BACKWARDS = 0;
+	var PDBOX_HISTORY_FORWARDS = 1;
+
+
+	var closePopstateFlag = false;
+	var historySupported = !! historyExt;
+
+
+	/**
+	 * Metoda pro zpracování redirect pole v odpovědi při otevřeném pdboxu.
+	 */
+	var handleRedirect = function(ext, payload, settings, requestHistory) {
+		var options = {
+			url: payload.redirect,
+			pdbox: true
+		};
+
+		if (! requestHistory) {
+			options.off = ['history'];
+		} else {
+			ext.historyEnabled = true;
+		}
+		if ('spinnerQueue' in settings) {
+			options.spinnerQueue = settings.spinnerQueue.slice(0);
+			settings.spinnerQueue = [];
+		}
+
+		$.nette.ajax(options);
+	};
+
+
 	$.nette.ext('pdbox', {
 		init: function () {
-			this.historySupported = !! historyExt;
-
 			this.ajaxified = initExt.linkSelector + ', ' + initExt.buttonSelector;
 
-			if (this.historySupported) {
+			if (historySupported) {
 				if (this.box) {
-					this.box.addEventListener('beforeOpen', $.proxy(function () {
-						// při otevření pdbox vždy uložíme kontext, který je pod pdbox, aby bylo možné po zavření vše vrátit zpět
-						if (this.popstate) {
-							this.original.push(this.lastState);
+					this.box.addEventListener('beforeOpen', (function (data) {
+						if (data.element && data.element.data('pdbox-history') === 'forwards') {
+							mode = PDBOX_HISTORY_FORWARDS;
+						} else {
+							mode = PDBOX_HISTORY_BACKWARDS;
 						}
-						else {
-							var state = {
-								location: location.href,
-								state: history.state,
-								title: document.title
-							};
-							this.original.push(state);
+
+						// pokud je mód historie dopředný, při otevření pdbox uložíme kontext, který je pod pdbox, aby
+						// bylo možné po zavření vše vrátit zpět
+						if (mode === PDBOX_HISTORY_FORWARDS) {
+							if (this.popstate) {
+								this.original.push(this.lastState);
+							}
+							else {
+								var state = {
+									location: location.href,
+									state: history.state,
+									title: document.title
+								};
+								this.original.push(state);
+							}
 						}
 
 						// navážeme událost po zavření
 						// aby nebyla duplicitní, odstraníme ji v případě, že byla dříve napojena
-						if (this.pushOriginalApplied) {
-							this.box.removeEventListener('afterClose', this.pushOriginalApplied);
+						if (this.afterCloseHandlerApplied) {
+							this.box.removeEventListener('afterClose', this.afterCloseHandlerApplied);
 						}
 
-						this.pushOriginalApplied = $.proxy(this.pushOriginal, this);
-						this.box.addEventListener('afterClose', this.pushOriginalApplied);
-					}, this));
+						this.afterCloseHandlerApplied = this.afterCloseHandler.bind(this);
+						this.box.addEventListener('afterClose', this.afterCloseHandlerApplied);
 
-					this.box.addEventListener('afterClose', $.proxy(function () {
+					}).bind(this));
+
+					this.box.addEventListener('afterClose', (function () {
 						if (this.xhr) {
 							this.xhr.abort();
 						}
-					}, this));
+					}).bind(this));
 				}
 			}
 		},
@@ -76,26 +126,11 @@
 			// pokud success nastal po kliknutí na elementu s class this.pdboxSelector, vyvoláme load událost, nastavíme vlastnosti pdbox a pokud je povolená historie, nahradíme stávající stav naším, kde přidáváme do state vlastnost pdbox
 			if (('nette' in settings && 'el' in settings.nette && settings.nette.el.is(this.pdboxSelector)) || settings.pdbox) {
 				// je pro současný request povolená historie?
-				var requestHistory = ($.inArray('history', settings.off) === -1 && this.historySupported);
+				var requestHistory = (! settings.off || settings.off.indexOf('history') === -1) && historySupported;
 
 				// zpracování vráceného redirectu v rámci pdbox
 				if (payload.redirect) {
-					var options = {
-						url: payload.redirect,
-						pdbox: true
-					};
-
-					if (! requestHistory) {
-						options.off = ['history'];
-					} else {
-						this.historyEnabled = true;
-					}
-					if ('spinnerQueue' in settings) {
-						options.spinnerQueue = settings.spinnerQueue.slice(0);
-						settings.spinnerQueue = [];
-					}
-
-					$.nette.ajax(options);
+					handleRedirect(this, payload, settings, requestHistory);
 
 					return;
 				}
@@ -145,25 +180,35 @@
 	}, {
 		pdboxSelector: '.js-pdbox',
 		pdboxAutoClass: 'js-pdbox',  // jde o název class, ne selector! automaticky nastavovaná třída ajax odkazům uvnitř otevřeného pdboxu; na tuto třídu by měl být pdbox též inicializován
-		historySupported: false, // nastavujeme v init
 		historyEnabled: false, // zabrání/povolí pushState po zavření okna pdbox; jdeme-li zpět (popstate), tak při zavření pdbox nechceme vkládat nový stav do historie, dále brání vložení stavu pro pdbox bez historie (např. obrázkový pdbox)
 		popstate: false,
-		pushOriginal: function () {
+		afterCloseHandler: function () {
 			// fce pro vložení stavu do historie, volá se po zavření pdbox; nový stav vkládá pouze pokud má co vložit (tj. víme co je pod pdbox) a pokud nezavíráme pdbox tlačítkem zpět
 			// pop stavu se vyvolá vždy při zavření pdbox, pushState ale chceme jen pokud není zavření vyvoláno popstatem
 			if (this.historyEnabled) {
-				var state = this.original.pop();
-				if (state) {
-					if (history.state === undefined || (history.state.href !== state.location)) { // zavření pdbox tlačítkem zpět pop je stejný stav, jako aktuální a nechceme jej zduplikovat
-						history.pushState(state.state, state.title, state.location);
-						document.title = state.title;
 
-						this.popstate = false;
-						this.lastState = {
-							location: state.location,
-							state: state.state,
-							title: state.title
-						};
+				if (mode === PDBOX_HISTORY_BACKWARDS) {
+
+					// Protože nevíme, o kolik stavů v historii jít zpět (v průběhu pdboxu mohlo stavů vzniknout více), vracíme se postupně po jednom, viz popsate
+					closePopstateFlag = true;
+					window.history.back();
+
+				} else if (mode === PDBOX_HISTORY_FORWARDS) {
+
+					var state = this.original.pop();
+					this.original = [];
+					if (state) {
+						if (history.state === undefined || (history.state.href !== state.location)) { // zavření pdbox tlačítkem zpět pop je stejný stav, jako aktuální a nechceme jej zduplikovat
+							history.pushState(state.state, state.title, state.location);
+							document.title = state.title;
+
+							this.popstate = false;
+							this.lastState = {
+								location: state.location,
+								state: state.state,
+								title: state.title
+							};
+						}
 					}
 				}
 
@@ -180,38 +225,54 @@
 
 	// "náš" popstate potřebujeme navázat před popstate.nette z history.nette.ajax.js, aby bylo možno v before callbacku
 	// správně detekovat, zda je pdbox otevřený, proto je inicializace mimo init callback rovnou po definici extension
-	if (historyExt) {
+	if (historySupported) {
 		var ext = $.nette.ext('pdbox');
-		var popstateHandler = $.proxy(function (e) {
+		var popstateHandler = function (e) {
 			var state = e.originalEvent.state || historyExt.initialState;
-			this.popstate = true;
+			var isPdboxState = 'pdbox' in state && state.pdbox;
+
+			ext.popstate = true;
+
+			// Nevíme, o kolik stavů jít zpět, proto postupně jdeme po jednom, dokud se nedostaneme ke stavu před
+			// pdboxem (tj. isPdboxState bude false).
+			if (closePopstateFlag) {
+				e.stopImmediatePropagation(); // nemáme zájem o popstate.nette (reálně o žádné další popstate handlery...)
+
+				if (isPdboxState) {
+					window.history.back();
+
+					return;
+				} else {
+					closePopstateFlag = false;
+				}
+			}
 
 			// při popstate kontrolujeme, zda nový stav má nastavenou vlastnost pdbox, pokud ano, otevřeme jej (metoda open kontroluje, zda již otevřený není), vložíme obsah a spustíme událost load
-			if ('pdbox' in state && state.pdbox) {
-				this.historyEnabled = true; // protože jde o popstate, jde o pdbox s historií (pokud je to pdbox, není třeba řešit tady), tj. nastavíme historyEnabled na true, aby po zavření křížkem došlo k pushState
+			if (isPdboxState) {
+				ext.historyEnabled = true; // protože jde o popstate, jde o pdbox s historií (pokud je to pdbox, není třeba řešit tady), tj. nastavíme historyEnabled na true, aby po zavření křížkem došlo k pushState
 
 				// předáváme virtuální DOM element, který není skutečným zdrojem otevření, ale má totožné data atributy, o které nám jde
 				var $opener = $(state.pdbox.opener);
 
-				this.box.open($opener);
-				this.box.content(state.pdbox.content);
-				this.box.setOptions(state.pdbox.options, true);
-				this.box.dispatchEvent('load', {element: $opener, content: state.pdbox.content});
+				ext.box.open($opener);
+				ext.box.content(state.pdbox.content);
+				ext.box.setOptions(state.pdbox.options, true);
+				ext.box.dispatchEvent('load', {element: $opener, content: state.pdbox.content});
 			} else {
-				this.historyEnabled = false; // zavíráme pomocí tlačítka zpět/vpřed, tj. nechceme zapisovat do historie
+				ext.historyEnabled = false; // zavíráme pomocí tlačítka zpět/vpřed, tj. nechceme zapisovat do historie
 
 				// pokud pdbox není, zavřeme jej (metoda close opět kontroluje, zda je pdbox otevřený)
-				this.box.close();
+				ext.box.close();
 			}
 
 			// udržujeme si aktuální stav, díky němu víme, kam se vracet (viz metoda open a push do original) i v případě popstate
 			// upravit až po otevření pdbox (pokud se otevíral, není třeba kontrolovat)
-			this.lastState = {
+			ext.lastState = {
 				location: location.href,
 				state: state,
 				title: document.title
 			};
-		}, ext);
+		};
 
 		$(window).on('popstate.pdbox', popstateHandler);
 	}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	"homepage": "https://github.com/peckadesign/pd.ajax",
 	"dependencies": {
 		"jquery": ">=1.12",
-		"nette.ajax.js": ">=2.0 <2.4",
+		"nette.ajax.js": "zipper/nette.ajax.js#~2.4.0",
 		"jquery.pdbox": "git+https://github.com/peckadesign/jquery.pdbox.git#semver:^1.2.0"
 	},
 	"devDependencies": {}

--- a/pd.ajax.js
+++ b/pd.ajax.js
@@ -66,10 +66,10 @@
 			if (! settings.nette.isForm && settings.nette.form && settings.nette.form.attr('data-ajax-pd')) {
 				ext = ((ext === '') ? '' : ext + ' ') + settings.nette.form.attr('data-ajax-pd');
 			}
-			return ext === '' || ext.split(' ');
+			return ext === '' ? [] : ext.split(' ');
 		}
 
-		return true;
+		return [];
 	};
 
 
@@ -89,53 +89,51 @@
 			});
 		},
 		prepare: function (settings) {
-			var on = getEnabledExtensions(settings);
+			settings.pd = getEnabledExtensions(settings);
+
 			$.each(extensions, function (name, ext) {
-				if (ext['prepare'] && $.inArray(name, on) !== -1) {
+				if (ext['prepare'] && settings.pd.indexOf(name) !== -1) {
 					ext.prepare(settings);
 				}
 			});
 		},
 		before: function (xhr, settings) {
-			var on = getEnabledExtensions(settings);
 			var abort = false;
+
 			$.each(extensions, function (name, ext) {
-				if (ext['before'] && $.inArray(name, on) !== -1) {
+				if (ext['before'] && settings.pd.indexOf(name) !== -1) {
 					if (ext.before(xhr, settings) === false) {
 						abort = true;
 					}
 				}
 			});
+
 			return !abort;
 		},
 		start: function (xhr, settings) {
-			var on = getEnabledExtensions(settings);
 			$.each(extensions, function (name, ext) {
-				if (ext['start'] && $.inArray(name, on) !== -1) {
+				if (ext['start'] && settings.pd.indexOf(name) !== -1) {
 					ext.start(xhr, settings);
 				}
 			});
 		},
 		success: function (payload, status, xhr, settings) {
-			var on = getEnabledExtensions(settings);
 			$.each(extensions, function (name, ext) {
-				if (ext['success'] && $.inArray(name, on) !== -1) {
+				if (ext['success'] && settings.pd.indexOf(name) !== -1) {
 					ext.success(payload, status, xhr, settings);
 				}
 			});
 		},
 		complete: function (xhr, status, settings) {
-			var on = getEnabledExtensions(settings);
 			$.each(extensions, function (name, ext) {
-				if (ext['complete'] && $.inArray(name, on) !== -1) {
+				if (ext['complete'] && settings.pd.indexOf(name) !== -1) {
 					ext.complete(xhr, status, settings);
 				}
 			});
 		},
 		error: function (xhr, status, error, settings) {
-			var on = getEnabledExtensions(settings);
 			$.each(extensions, function (i, ext) {
-				if (ext['error'] && $.inArray(name, on) !== -1) {
+				if (ext['error'] && settings.pd.indexOf(name) !== -1) {
 					ext.error(xhr, status, error, settings);
 				}
 			});


### PR DESCRIPTION
PR pro issue #13, #7 a #15.

- U pdboxu je možné nastavit způsob fungování historie po zavření. Výchozí je, že po zavření přejde prohlížeč zpět do stavu před otevřením a v historii prohlížeče je pdbox možno otevřít tlačítkem vpřed. Pomocí `data-pdbox-history="forwards"` je možné nastavit, že při zavření se vytvoří nový stav do historie, tj. tlačítko zpět v prohlížeči otevře znovu tento pdbox.
- V jednotlivých extension je v `settings.pd` dostupné pole pro request zapnutých pd extension. 
- Do extension se neukládá každý `xhr`, ale pouze ty, které opravdu souvisí s `pdboxem`. Stejně tak k rušení dojde pouze v případě, že oba requesty (probíhající i nový) souvisí s `pdboxem`. Opravuje #7.
- Přesunutí automatického přidávání class `js-pdbox` (obecně dle nastavení `autoclass` u extension) tak, aby i při `popstate` došlo k nastavení class uvnitř pdboxu, opravuje #15.


- **Nové extension:** Přidáno extension `replaceState` pro zachování změny url bez vytváření nových stavů. Toto extension je možné použít obecně vždy, když chceme mít aktuální url, ale v historii nechceme vytvářet nový stav. Například přepínání barev produktů nebo formuláře v pdboxu.

:warning: **BC break:** původní výchozí chování historie pdboxu bylo to, které je nyní volitelné, tj. vytváření nového stavu po zavření. Pro zachování tohoto chování je potřeba doplnit zmíněný data atribut `data-pdbox-history="forwards"`.

