### PR TITLE
Prerelease 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ Vlastní extensions pro nette.ajax
 
 ## Changelog
 
+### 1.5.0
+- AJAXové odesílání formulářů nyní rozlišuje, zda je class `ajax` na formuláři nebo odesílacím tlačítku. Předchozí verze vždy pro odeslání používaly událost `click`, tj. nikdy nedošlo k `submit` události. Nově, pokud je `class="ajax"` na formuláři, dojde k AJAXovému odeslání z události `submit` formuláře. 
+- Spinner z tlačítka z extension `btnSpinner` se neodstraňuje v případě, že v AJAXové odpovědi přišlo `forceReload`.
+
 ### 1.4.3
 - V extension `spinner` se nově neodstraňuje spinner z DOM i v případě, že v JSONu AJAXové odpovědi přijde pole `forceReload`. V tu chvíli je chování extension `spinner` totožné s případem, kdy dojde `forceRedirect`.
 - **Nové extension:** Přidáno extension `forceReload`, které zajistí znovunačtení stránky v případě, že v odpovědi přišlo `forceRedirect: true`. Pokud je v odpovědi i `_fid`, je přidáno do URL pro načtení.

--- a/extensions/pd/btnSpinner.ajax.js
+++ b/extensions/pd/btnSpinner.ajax.js
@@ -55,7 +55,7 @@
 			}
 		},
 		complete: function (xhr, status, settings) {
-			if (! ('forceRedirect' in xhr) && '$btnSpinner' in settings) {
+			if (! ('forceRedirect' in xhr) && ! ('forceReload' in xhr) && '$btnSpinner' in settings) {
 				settings.$btnSpinner.remove();
 			}
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd.ajax",
 	"title": "pd.ajax",
 	"description": "Collection of nette ajax extensions, including `pd` for creating disabled-by-deafult extensions",
-	"version": "1.4.3",
+	"version": "1.5.0",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/pd.ajax.js
+++ b/pd.ajax.js
@@ -5,7 +5,7 @@
  * @copyright Copyright (c) 2015      Jiří Pudil
  * @license MIT
  *
- * @version 1.4.3
+ * @version 1.5.0
  */
 (function ($, undefined) {
 	var extensions = {};
@@ -23,7 +23,7 @@
 	}, {
 		linkSelector: 'a.ajax',
 		formSelector: 'form.ajax',
-		buttonSelector: 'input.ajax[type="submit"], form.ajax input[type="submit"], button.ajax[type="submit"], form.ajax button[type="submit"], input.ajax[type="image"], form.ajax input[type="image"]'
+		buttonSelector: 'input.ajax[type="submit"], button.ajax[type="submit"], input.ajax[type="image"]'
 	});
 
 	// Allows calling $.nette.pd.ext('foo') to get pd extension context (same as $.nette.ext('bar') for common extension)
@@ -60,12 +60,23 @@
 		}
 		if (settings.nette) {
 			var ext = '';
+
+			// pd extension z elementu
 			if (settings.nette.el.attr('data-ajax-pd')) {
 				ext = settings.nette.el.attr('data-ajax-pd');
 			}
+
+			// Pokud el není formulář, ale existuje formulář, hledáme i na něm
 			if (! settings.nette.isForm && settings.nette.form && settings.nette.form.attr('data-ajax-pd')) {
 				ext = ((ext === '') ? '' : ext + ' ') + settings.nette.form.attr('data-ajax-pd');
 			}
+
+			// Pokud je el formulář a známe odesílací tlačítko, hledáme na něm
+			if (settings.nette.isForm && settings.nette.form.get(0)['nette-submittedBy']) {
+				var btn = settings.nette.form.get(0)['nette-submittedBy'];
+				ext = ((ext === '') ? '' : ext + ' ') + btn.attr('data-ajax-pd');
+			}
+
 			return ext === '' ? [] : ext.split(' ');
 		}
 


### PR DESCRIPTION
- AJAXové odesílání formulářů nyní rozlišuje, zda je class `ajax` na formuláři nebo odesílacím tlačítku. Předchozí verze vždy pro odeslání používaly událost `click`, tj. nikdy nedošlo k `submit` události. Nově, pokud je `class="ajax"` na formuláři, dojde k AJAXovému odeslání z události `submit` formuláře.

- Spinner z tlačítka z extension `btnSpinner` se neodstraňuje v případě, že v AJAXové odpovědi přišlo `forceReload`.