### PR TITLE
#23 Extension `forceReload` rozbíjí url s hashem

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 Vlastní extensions pro nette.ajax
 
 ## Changelog
+### 1.4.8
+- Oprava chyby [#23](https://github.com/peckadesign/pd.ajax/issues/23), kdy extension `forceReload` v případě kombinace hashe a parametrů rozbíjelo URL.
+
 ### 1.4.7
 - Extension `uniqueForm` je možno vypnout i na neeajaxových formulářích a to stejným způsobem, jako jinde, tj. pomocí `data-ajax-off="uniqueForm"` buď na formuláři, nebo na tlačítku. Řeší issue [#21](https://github.com/peckadesign/pd.ajax/issues/21).
 

--- a/extensions/forceReload.ajax.js
+++ b/extensions/forceReload.ajax.js
@@ -22,19 +22,33 @@
 		}
 	}, {
 		addFid: function(href, _fid) {
-			var s = '?';
+			var hashStart = href.indexOf('#');
+			var hash = '';
+			var c = '?';
 
-			if ((i = href.search(/\?/)) !== -1) {
-				s = '&';
+			if (hashStart > -1) {
+				hash = href.substring(hashStart);
+				href = href.substring(0, hashStart);
 			}
 
-			href += s + '_fid=' + _fid;
+			if ((i = href.search(/\?/)) !== -1) {
+				c = '&';
+			}
 
-			return href;
+			href += c + '_fid=' + _fid;
+
+			return href + hash;
 		},
 		removeFid: function(href) {
 			// je v URL _fid?
 			var fidStart = href.indexOf('_fid=');
+			var hashStart = href.indexOf('#');
+			var hash = '';
+
+			if (hashStart > -1) {
+				hash = href.substring(hashStart);
+				href = href.substring(0, hashStart);
+			}
 
 			if (fidStart > -1) {
 				// Odstranění _fid parametru
@@ -53,7 +67,7 @@
 
 			}
 
-			return href;
+			return href + hash;
 		}
 	});
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd.ajax",
 	"title": "pd.ajax",
 	"description": "Collection of nette ajax extensions, including `pd` for creating disabled-by-deafult extensions",
-	"version": "1.4.7",
+	"version": "1.4.8",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/pd.ajax.js
+++ b/pd.ajax.js
@@ -5,7 +5,7 @@
  * @copyright Copyright (c) 2015      Jiří Pudil
  * @license MIT
  *
- * @version 1.4.7
+ * @version 1.4.8
  */
 (function ($, undefined) {
 	var extensions = {};


### PR DESCRIPTION
PR k úkolu #23

- Oprava mazání a přidávání parametrů do URL v případě, že URL obsahuje hash