### PR TITLE
#0 Ošetření popstate handleru v případě, že není `state` nebo instance `pdBox`

### DIFF
--- a/extensions/pdbox.ajax.js
+++ b/extensions/pdbox.ajax.js
@@ -264,8 +264,12 @@
 		var pdboxExt = $.nette.ext('pdbox');
 		var popstateHandler = function (e) {
 			var state = e.originalEvent.state || historyExt.initialState;
-			var isPdboxState = 'pdbox' in state && state.pdbox;
 
+			if (typeof state === 'undefined' || pdboxExt.box === null) {
+				return;
+			}
+
+			var isPdboxState = 'pdbox' in state && state.pdbox;
 			pdboxExt.popstate = true;
 
 			// Nevíme, o kolik stavů jít zpět, proto postupně jdeme po jednom, dokud se nedostaneme ke stavu před


### PR DESCRIPTION
- Kvůli chybné implementaci JS History API dochází na macOS / iOS zařízeních k popstatě při načtení stránky, v takovém případě chybí `state` a `popstateHandler` neprovádíme.
- V případě, že k popstate dojde dřív, než byl inicializován `pdBox`, pak v `popstateHandler` je `pdboxExt.box === null` a dojde k chybě při pokusu o volání metod nad tímto objektem.