### PR TITLE
Extension `inpNumber` respektuje při inicializaci `disabled` na inputu

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 Vlastní extensions pro nette.ajax
 
 ## Changelog
+### 1.4.10
+- Extension `inpNumber` respektuje při inicializaci `disabled` na inputu. Programová změna za běhu není reflektována, je nutné zavolat ručně metodu `$('#foo').data('inpNumber').setDisabledBtns()` pro daný `.inp-number`.
+
+## Changelog
 ### 1.4.9
 - Ošetření popstate handleru v případě, že není `state` nebo instance `pdBox`.
 

--- a/extensions/inpNumber.ajax.js
+++ b/extensions/inpNumber.ajax.js
@@ -78,12 +78,12 @@
 				.data('disabled', false)
 				.removeClass('inp-number__btn--disabled');
 
-			if (value === this.min) {
+			if (value === this.min || this.$input.is(':disabled')) {
 				this.$dec
 					.data('disabled', true)
 					.addClass('inp-number__btn--disabled');
 			}
-			if (value === this.max) {
+			if (value === this.max || this.$input.is(':disabled')) {
 				this.$inc
 					.data('disabled', true)
 					.addClass('inp-number__btn--disabled');
@@ -119,7 +119,8 @@
 			e.preventDefault();
 
 			// už zpracováváme z click event -> desktop, takže longtap ignorujeme
-			if (e.type === 'longtap' && this.rapidChangeFlag) {
+			// nebo je tlačítko disabled
+			if ((e.type === 'longtap' && this.rapidChangeFlag) || this.isClickedBtnDisabled(e)) {
 				return;
 			}
 
@@ -198,6 +199,7 @@
 				.find(this.selector)
 				.each(function() {
 					var inpNumber = new InpNumber(this);
+					$(this).data('inpNumber', inpNumber);
 				});
 		}
 	});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd.ajax",
 	"title": "pd.ajax",
 	"description": "Collection of nette ajax extensions, including `pd` for creating disabled-by-deafult extensions",
-	"version": "1.4.9",
+	"version": "1.4.10",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/pd.ajax.js
+++ b/pd.ajax.js
@@ -5,7 +5,7 @@
  * @copyright Copyright (c) 2015      Jiří Pudil
  * @license MIT
  *
- * @version 1.4.8
+ * @version 1.4.10
  */
 (function ($, undefined) {
 	var extensions = {};


### PR DESCRIPTION
Extension `inpNumber` respektuje při inicializaci `disabled` na inputu. Programová změna za běhu není reflektována, je nutné zavolat ručně metodu `$('#foo').data('inpNumber').setDisabledBtns()` pro daný `.inp-number`.