### PR TITLE
Oprava procházení zpět historií přes pdbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 Vlastní extensions pro nette.ajax
 
 ## Changelog
+### 1.4.11
+- Oprava procházení zpět historií přes pdbox. Pokud otevřeme pdbox s historií v pdboxu (např. předkošík) a z něj klikneme na další stránku (např. do košíku), otevře se při použití zpět prohlížeče nejprve správně předkošík, ale při dalším zpět se pouze změní url a stránka se nezmění. Tento release to opravuje.
+
 ### 1.4.10
 - Extension `inpNumber` respektuje při inicializaci `disabled` na inputu. Programová změna za běhu není reflektována, je nutné zavolat ručně metodu `$('#foo').data('inpNumber').setDisabledBtns()` pro daný `.inp-number`.
 
-## Changelog
 ### 1.4.9
 - Ošetření popstate handleru v případě, že není `state` nebo instance `pdBox`.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd.ajax",
 	"title": "pd.ajax",
 	"description": "Collection of nette ajax extensions, including `pd` for creating disabled-by-deafult extensions",
-	"version": "1.4.10",
+	"version": "1.4.11",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/pd.ajax.js
+++ b/pd.ajax.js
@@ -5,7 +5,7 @@
  * @copyright Copyright (c) 2015      Jiří Pudil
  * @license MIT
  *
- * @version 1.4.10
+ * @version 1.4.11
  */
 (function ($, undefined) {
 	var extensions = {};


### PR DESCRIPTION
Pokud otevřeme pdbox s historií v pdboxu (např. předkošík) a z něj klikneme na další stránku (např. do košíku), otevře se při použití zpět prohlížeče nejprve správně předkošík, ale při dalším zpět se pouze změní url a stránka se nezmění. Tento release to opravuje.