### PR TITLE
Přidáno extension `cookieConsent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 Vlastní extensions pro nette.ajax
 
 ## Changelog
+
+### 1.4.12
+- **Nové extension:** Přidáno extension `cookieConsent`, které po odeslání formuláře na základě data atributů spustí na webu scripty z daných kategorií. V odeslaném formuláři se hledají checkboxy s data atributem `data-cookie-consent-category`, jehož obsahem je název kategorie. Tento název se pak využívá na script tagu v jiném data atributu. Spuštění funguje jak pro inline JS, tak pro externí JS. Například:
+  ```html
+  <input n:name="marketing" data-cookie-consent-category="marketing">
+  
+  ...
+  
+  <script type="text/plain" data-cookie-consent="marketing">
+      (function () { /* ... */ })();
+  </script>
+  <script type="text/plain" data-cookie-consent="marketing" src="/js/marketing.js"></script>
+```
+
 ### 1.4.11
 - Oprava procházení zpět historií přes pdbox. Pokud otevřeme pdbox s historií v pdboxu (např. předkošík) a z něj klikneme na další stránku (např. do košíku), otevře se při použití zpět prohlížeče nejprve správně předkošík, ale při dalším zpět se pouze změní url a stránka se nezmění. Tento release to opravuje.
 

--- a/extensions/pd/cookieConsent.ajax.js
+++ b/extensions/pd/cookieConsent.ajax.js
@@ -1,0 +1,82 @@
+(function($, undefined) {
+
+	/**
+	 * @author Radek Šerý
+	 *
+	 * Cookie consent extension, které zajistí spuštění scriptů.
+	 */
+	$.nette.pd.ext('cookieConsent', {
+		success: function (payload, status, xhr, settings) {
+			if (! 'nette' in settings || ! settings.nette.form) {
+				return;
+			}
+
+			var consentCategories = this.getAcceptedCategories(settings.nette.form[0]);
+
+			if (consentCategories.length) {
+				var scripts = this.getScripts(consentCategories);
+				this.runScripts(scripts);
+			}
+
+			this.closeCookieConsent(settings);
+		}
+	}, {
+		getAcceptedCategories: function (form) {
+			var categories = [];
+			var acceptAll = form['nette-submittedBy'] && $(form['nette-submittedBy']).is('[data-cookie-consent-accept-all]')
+
+			for (var i = 0; i < form.elements.length; i++) {
+				var consent = form.elements[i].getAttribute('data-cookie-consent-category');
+
+				if (consent && (acceptAll || form.elements[i].checked)) {
+					categories.push(consent);
+				}
+			}
+
+			return categories;
+		},
+		getScripts: function (categories) {
+			var selectors = [];
+
+			categories.forEach(function(category) {
+				selectors.push('script[data-cookie-consent="' + category + '"]');
+			});
+
+			return document.querySelectorAll(selectors.join(','));
+		},
+		runScripts: function (scripts) {
+			for (var i = 0; i < scripts.length; i++) {
+				this.runScript(scripts[i])
+			}
+		},
+		runScript: function (script) {
+			var scriptRunnable = document.createElement('script');
+
+			if (script.src) {
+				scriptRunnable.src = script.src;
+			} else {
+				scriptRunnable.innerHTML = script.innerHTML;
+			}
+
+			scriptRunnable.async = script.async
+			scriptRunnable.defer = script.defer
+
+			scriptRunnable.crossOrigin = script.crossOrigin
+			scriptRunnable.referrerPolicy = script.referrerPolicy
+
+			script.insertAdjacentElement('afterend', scriptRunnable);
+			script.remove();
+		},
+		closeCookieConsent: function (settings) {
+			var $modal = settings.nette.form.closest('.js-cookie-modal');
+			var closingDuration = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--pdbox-closing-duration') || 0);
+
+			$modal.addClass('cookie-modal--close');
+
+			setTimeout(function() {
+				$modal.remove();
+			}, closingDuration);
+		}
+	});
+
+})(jQuery);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd.ajax",
 	"title": "pd.ajax",
 	"description": "Collection of nette ajax extensions, including `pd` for creating disabled-by-deafult extensions",
-	"version": "1.4.11",
+	"version": "1.4.12",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/pd.ajax.js
+++ b/pd.ajax.js
@@ -5,7 +5,7 @@
  * @copyright Copyright (c) 2015      Jiří Pudil
  * @license MIT
  *
- * @version 1.4.11
+ * @version 1.4.12
  */
 (function ($, undefined) {
 	var extensions = {};


### PR DESCRIPTION
Přidáno extension `cookieConsent`, které po odeslání formuláře na základě data atributů spustí na webu scripty z daných kategorií. V odeslaném formuláři se hledají checkboxy s data atributem `data-cookie-consent-category`, jehož obsahem je název kategorie. Tento název se pak využívá na script tagu v jiném data atributu. Spuštění funguje jak pro inline JS, tak pro externí JS. Použití příklad viz release 1.4.12.