### PR TITLE
Extension `cookieConsent` při zavírání modálu vyvolává události

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Vlastní extensions pro nette.ajax
 
 ## Changelog
 
+### 1.4.14
+- Extension cookieConsent při zavírání modálu vyvolává dvě události - `cookieConsentBeforeClose` a `cookieConsentAfterClose`.
+
 ### 1.4.13
 - Dependency update, povolení vyšší verze `nette.ajax.js` (`^2.4.0`).
 

--- a/extensions/pd/cookieConsent.ajax.js
+++ b/extensions/pd/cookieConsent.ajax.js
@@ -71,10 +71,13 @@
 			var $consentEl = settings.nette.form.closest('.js-cookie-consent');
 			var closingDuration = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--cookie-consent-closing-duration') || 0);
 
+			document.dispatchEvent(new CustomEvent('cookieConsentBeforeClose', { bubbles: true }))
+
 			$consentEl.addClass('js-cookie-consent--close');
 
 			setTimeout(function() {
 				$consentEl.remove();
+				document.dispatchEvent(new CustomEvent('cookieConsentAfterClose', { bubbles: true }))
 			}, closingDuration);
 		}
 	});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd.ajax",
 	"title": "pd.ajax",
 	"description": "Collection of nette ajax extensions, including `pd` for creating disabled-by-deafult extensions",
-	"version": "1.4.13",
+	"version": "1.4.14",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/pd.ajax.js
+++ b/pd.ajax.js
@@ -5,7 +5,7 @@
  * @copyright Copyright (c) 2015      Jiří Pudil
  * @license MIT
  *
- * @version 1.4.13
+ * @version 1.4.14
  */
 (function ($, undefined) {
 	var extensions = {};


### PR DESCRIPTION
Extension `cookieConsent` při zavírání modálu vyvolává dvě události - `cookieConsentBeforeClose` a `cookieConsentAfterClose`.