### PR TITLE
#0 jQuery 4 compatibility – replace removed APIs

### DIFF
--- a/extensions/inpNumber.ajax.js
+++ b/extensions/inpNumber.ajax.js
@@ -27,14 +27,14 @@
 
 		// bind handlers
 		this.$btns
-			.on('click', $.proxy(this.handleClick, this))
+			.on('click', this.handleClick.bind(this))
 			.on('contextmenu', function(e) { e.preventDefault(); }) // longtap na Android zařízeních otevírá menu; pro iOS je nutné uvést v css -webkit-touch-callout: none;
-			.on('mousedown longtap', $.proxy(this.startRapidChange, this))
-			.on('mouseup mouseleave touchend touchcancel', $.proxy(this.stopRapidChange, this));
+			.on('mousedown longtap', this.startRapidChange.bind(this))
+			.on('mouseup mouseleave touchend touchcancel', this.stopRapidChange.bind(this));
 
 		this.$input
-			.on('change', $.proxy(this.handleChange, this)) // mouseup není vyvoláno, pokud z tlačítka sjedeme, proto mouseleave
-			.on('focus', $.proxy(this.handleFocus, this));
+			.on('change', this.handleChange.bind(this)) // mouseup není vyvoláno, pokud z tlačítka sjedeme, proto mouseleave
+			.on('focus', this.handleFocus.bind(this));
 	};
 
 	InpNumber.prototype = {

--- a/extensions/pd/suggest.ajax.js
+++ b/extensions/pd/suggest.ajax.js
@@ -20,16 +20,16 @@
 		this.timeout = options.timeout || 200;
 
 		this.$form
-			.on('keydown', inputSelector, $.proxy(this.handleInputKeydown, this))
-			.on('keyup', inputSelector, $.proxy(this.handleInputKeyup, this));
+			.on('keydown', inputSelector, this.handleInputKeydown.bind(this))
+			.on('keyup', inputSelector, this.handleInputKeyup.bind(this));
 
 		this.$input
 			.data('document-tap-blur', false)
-			.on('focus', $.proxy(this.showSuggest, this))
-			.on('blur', $.proxy(this.hideSuggest, this));
+			.on('focus', this.showSuggest.bind(this))
+			.on('blur', this.hideSuggest.bind(this));
 
 		this.$suggest
-			.on('mousedown', $.proxy(this.handleSuggestMousedown, this));
+			.on('mousedown', this.handleSuggestMousedown.bind(this));
 
 		this.$form.data('pdSuggest', this);
 	};

--- a/extensions/uniqueForm.ajax.js
+++ b/extensions/uniqueForm.ajax.js
@@ -49,7 +49,7 @@
 			var $form = $(form);
 			clearTimeout($form.data('uniqueFormTimeout'));
 			$form.removeData('uniqueFormTimeout')
-				.bind('submit', uniqueForm.formSubmitHandler)
+				.on('submit', uniqueForm.formSubmitHandler)
 			;
 			setTimeout(function () {
 				// disabled je třeba nastavit opožděně, aby formulář odeslal v POST requestu i submit button
@@ -63,7 +63,7 @@
 			var $form = $(form);
 			clearTimeout($form.data('uniqueFormTimeout'));
 			$form.removeData('uniqueFormTimeout')
-				.unbind('submit', uniqueForm.formSubmitHandler)
+				.off('submit', uniqueForm.formSubmitHandler)
 			;
 
 			setTimeout(function () {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pd.ajax",
 	"title": "pd.ajax",
 	"description": "Collection of nette ajax extensions, including `pd` for creating disabled-by-deafult extensions",
-	"version": "1.4.15",
+	"version": "1.5.0",
 	"author": "PeckaDesign, s.r.o <support@peckadesign.cz>",
 	"contributors": [
 		"Radek Šerý <radek.sery@peckadesign.cz>",

--- a/pd.ajax.js
+++ b/pd.ajax.js
@@ -5,7 +5,7 @@
  * @copyright Copyright (c) 2015      Jiří Pudil
  * @license MIT
  *
- * @version 1.4.15
+ * @version 1.5.0
  */
 (function ($, undefined) {
 	var extensions = {};
@@ -36,7 +36,7 @@
 			} else {
 				var extension = {};
 				$.each(callbacks, function (event, callback) {
-					extension[event] = $.proxy(callback, context);
+					extension[event] = callback.bind(context);
 				});
 				extensions[name] = extension;
 				contexts[name] = $.extend(context ? context : {}, {


### PR DESCRIPTION
- $.proxy() → fn.bind() in pd.ajax.js, inpNumber.ajax.js, suggest.ajax.js
- .bind()/.unbind() → .on()/.off() in uniqueForm.ajax.js
- Version 1.5.0 (MINOR – adds jQuery 4 support, backward compatible with jQuery 3)